### PR TITLE
Removed use of wide cam in EON/C2.

### DIFF
--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -755,7 +755,6 @@ void AnnotatedCameraWidget::paintGL() {
 
   CameraWidget::setStreamType(VISION_STREAM_ROAD);
 
-  s->scene.wide_cam = false;
   if (s->scene.calibration_valid) {
     CameraWidget::updateCalibration(s->scene.view_from_calib);
   } else {

--- a/selfdrive/ui/qt/widgets/cameraview_qcom.cc
+++ b/selfdrive/ui/qt/widgets/cameraview_qcom.cc
@@ -202,13 +202,9 @@ void CameraWidget::updateFrameMat() {
     if (active_stream_type == VISION_STREAM_DRIVER) {
       frame_mat = matmul(device_transform, get_driver_view_transform(w, h, stream_width, stream_height));
     } else {
-      intrinsic_matrix = active_stream_type == VISION_STREAM_WIDE_ROAD ? ecam_intrinsic_matrix : fcam_intrinsic_matrix;
-      zoom = ZOOM / intrinsic_matrix.v[0];
-      if (active_stream_type == VISION_STREAM_WIDE_ROAD) {
-        zoom *= 0.5;
-      }
-      float zx = zoom * 2 * intrinsic_matrix.v[2] / w;
-      float zy = zoom * 2 * intrinsic_matrix.v[5] / h;
+      zoom = ZOOM / fcam_intrinsic_matrix.v[0];
+      float zx = zoom * 2 * fcam_intrinsic_matrix.v[2] / w;
+      float zy = zoom * 2 * fcam_intrinsic_matrix.v[5] / h;
 
       const mat4 frame_transform = {{
         zx, 0.0, 0.0, 0.0,

--- a/selfdrive/ui/qt/widgets/cameraview_qcom.h
+++ b/selfdrive/ui/qt/widgets/cameraview_qcom.h
@@ -66,7 +66,6 @@ protected:
   float y_offset = 0;
   float zoom = 1.0;
   mat3 calibration = DEFAULT_CALIBRATION;
-  mat3 intrinsic_matrix = fcam_intrinsic_matrix;
 
   std::recursive_mutex frame_lock;
   std::deque<std::pair<uint32_t, VisionBuf*>> frames;

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -79,7 +79,7 @@ void update_line_data(const UIState *s, const cereal::XYZTData::Reader &line,
   *pvd = left_points + right_points;
 }
 
-void update_model(UIState *s, 
+void update_model(UIState *s,
                   const cereal::ModelDataV2::Reader &model,
                   const cereal::UiPlan::Reader &plan) {
   UIScene &scene = s->scene;
@@ -166,21 +166,29 @@ static void update_state(UIState *s) {
     if (rpy_list.size() == 3) rpy << rpy_list[0], rpy_list[1], rpy_list[2];
     if (wfde_list.size() == 3) wfde << wfde_list[0], wfde_list[1], wfde_list[2];
     Eigen::Matrix3d device_from_calib = euler2rot(rpy);
+    #ifndef QCOM
     Eigen::Matrix3d wide_from_device = euler2rot(wfde);
+    #endif
     Eigen::Matrix3d view_from_device;
     view_from_device << 0,1,0,
                         0,0,1,
                         1,0,0;
     Eigen::Matrix3d view_from_calib = view_from_device * device_from_calib;
+    #ifndef QCOM
     Eigen::Matrix3d view_from_wide_calib = view_from_device * wide_from_device * device_from_calib ;
+    #endif
     for (int i = 0; i < 3; i++) {
       for (int j = 0; j < 3; j++) {
         scene.view_from_calib.v[i*3 + j] = view_from_calib(i,j);
+        #ifndef QCOM
         scene.view_from_wide_calib.v[i*3 + j] = view_from_wide_calib(i,j);
+        #endif
       }
     }
     scene.calibration_valid = sm["liveCalibration"].getLiveCalibration().getCalStatus() == 1;
+    #ifndef QCOM
     scene.calibration_wide_valid = wfde_list.size() == 3;
+    #endif
   }
   if (sm.updated("pandaStates")) {
     auto pandaStates = sm["pandaStates"].getPandaStates();

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -111,7 +111,11 @@ const QColor bg_colors [] = {
 typedef struct UIScene {
   bool calibration_valid = false;
   bool calibration_wide_valid  = false;
+  #ifndef QCOM
   bool wide_cam = true;
+  #else
+  bool wide_cam = false;
+  #endif
   mat3 view_from_calib = DEFAULT_CALIBRATION;
   mat3 view_from_wide_calib = DEFAULT_CALIBRATION;
   cereal::PandaState::PandaType pandaType;


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
