### PR TITLE
Point panda and opendbc submodules to dragaonpilot-community repo legacy branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "panda"]
   path = panda
-  url = ../../commaai/panda.git
+  url = ../../dragonpilot-community/panda.git
+  branch = legacy
 [submodule "opendbc"]
   path = opendbc
-  url = ../../commaai/opendbc.git
+  url = ../../dragonpilot-community/opendbc.git
+  branch = legacy
 [submodule "laika_repo"]
   path = laika_repo
   url = ../../commaai/laika.git


### PR DESCRIPTION
Reference dragonpilot-community repo and legacy branch for panda and opendbc submodules instead of upstream